### PR TITLE
Refactors CSP flyout props for preview mode

### DIFF
--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/public/src/types.ts
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/public/src/types.ts
@@ -81,16 +81,38 @@ export interface FindingsAggs {
   count: estypes.AggregationsMultiBucketAggregateBase<estypes.AggregationsStringRareTermsBucketKeys>;
 }
 
-export interface FindingMisconfigurationFlyoutProps extends Record<string, unknown> {
+interface BaseFlyoutProps {
   ruleId: string;
   resourceId: string;
-  isPreviewMode?: boolean;
-  scopeId?: string;
 }
-export interface FindingsMisconfigurationPanelExpandableFlyoutProps extends FlyoutPanelProps {
-  key: 'findings-misconfiguration-panel' | 'findings-misconfiguration-panel-preview';
-  params: FindingMisconfigurationFlyoutProps;
+
+interface PreviewModeProps {
+  isPreviewMode: true;
+  scopeId: string;
+  banner: {
+    title: string;
+    backgroundColor: string;
+    textColor: string;
+  };
 }
+
+interface NonPreviewModeProps {
+  isPreviewMode?: false | undefined;
+}
+export type FindingsMisconfigurationPanelExpandableFlyoutPropsNonPreview = FlyoutPanelProps & {
+  id: 'findings-misconfiguration-panel';
+  params: BaseFlyoutProps & NonPreviewModeProps;
+};
+
+export type FindingsMisconfigurationPanelExpandableFlyoutPropsPreview = FlyoutPanelProps & {
+  id: 'findings-misconfiguration-panel-preview';
+  params: BaseFlyoutProps & PreviewModeProps;
+};
+
+export type FindingsMisconfigurationPanelExpandableFlyoutProps =
+  | FindingsMisconfigurationPanelExpandableFlyoutPropsNonPreview
+  | FindingsMisconfigurationPanelExpandableFlyoutPropsPreview;
+
 export interface FindingsMisconfigurationFlyoutHeaderProps {
   finding: CspFinding;
 }

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/plugin.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/plugin.tsx
@@ -12,9 +12,9 @@ import { RedirectAppLinks } from '@kbn/shared-ux-link-redirect-app';
 import type {
   CspClientPluginStartDeps,
   FindingMisconfigurationFlyoutFooterProps,
-  FindingMisconfigurationFlyoutProps,
   FindingsMisconfigurationFlyoutContentProps,
   FindingsMisconfigurationFlyoutHeaderProps,
+  FindingsMisconfigurationPanelExpandableFlyoutProps,
 } from '@kbn/cloud-security-posture';
 import { uiMetricService } from '@kbn/cloud-security-posture-common/utils/ui_metrics';
 import { CspLoadingState } from './components/csp_loading_state';
@@ -123,7 +123,7 @@ export class CspPlugin
       getCloudSecurityPostureRouter: () => App,
       getCloudSecurityPostureMisconfigurationFlyout: () => {
         return {
-          Component: (props: FindingMisconfigurationFlyoutProps) => (
+          Component: (props: FindingsMisconfigurationPanelExpandableFlyoutProps['params']) => (
             <LazyCspFindingsMisconfigurationFlyout {...props}>
               {props.children}
             </LazyCspFindingsMisconfigurationFlyout>

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/types.ts
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/types.ts
@@ -14,10 +14,11 @@ import type { FleetSetup } from '@kbn/fleet-plugin/public';
 import type { UsageCollectionSetup } from '@kbn/usage-collection-plugin/public';
 import { ExpandableFlyoutApi } from '@kbn/expandable-flyout';
 import {
+  FindingMisconfigurationFlyoutContentProps,
   FindingMisconfigurationFlyoutFooterProps,
-  FindingMisconfigurationFlyoutProps,
   FindingsMisconfigurationFlyoutContentProps,
   FindingsMisconfigurationFlyoutHeaderProps,
+  FindingsMisconfigurationPanelExpandableFlyoutProps,
 } from '@kbn/cloud-security-posture';
 import type { CspRouterProps } from './application/csp_router';
 import type { CloudSecurityPosturePageId } from './common/navigation/types';
@@ -43,7 +44,11 @@ export interface CspClientPluginStart {
   getCloudSecurityPostureRouter(): ComponentType<CspRouterProps>;
   // getCloudSecurityPostureMisconfigurationFlyout: () => React.JSX.Element;
   getCloudSecurityPostureMisconfigurationFlyout: () => {
-    Component: React.FC<FindingMisconfigurationFlyoutProps>;
+    Component: React.FC<
+      FindingsMisconfigurationPanelExpandableFlyoutProps['params'] & {
+        children?: (props: FindingMisconfigurationFlyoutContentProps) => ReactNode;
+      }
+    >;
     Header: React.FC<FindingsMisconfigurationFlyoutHeaderProps>;
     Body: React.FC<FindingsMisconfigurationFlyoutContentProps>;
     Footer: React.FC<FindingMisconfigurationFlyoutFooterProps>;

--- a/x-pack/solutions/security/plugins/security_solution/public/cloud_security_posture/components/csp_details/misconfiguration_findings_details_table.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/cloud_security_posture/components/csp_details/misconfiguration_findings_details_table.tsx
@@ -21,6 +21,7 @@ import {
 } from '@kbn/cloud-security-posture-common';
 import { DistributionBar } from '@kbn/security-solution-distribution-bar';
 import type { CspBenchmarkRuleMetadata } from '@kbn/cloud-security-posture-common/schema/rules/latest';
+import type { FindingsMisconfigurationPanelExpandableFlyoutPropsPreview } from '@kbn/cloud-security-posture';
 import { CspEvaluationBadge, getMisconfigurationStatusColor } from '@kbn/cloud-security-posture';
 
 import {
@@ -214,12 +215,14 @@ export const MisconfigurationFindingsDetailsTable = memo(
                 METRIC_TYPE.CLICK,
                 NAV_TO_FINDINGS_BY_RULE_NAME_FRPOM_ENTITY_FLYOUT
               );
-              openPreviewPanel({
+
+              const previewPanelProps: FindingsMisconfigurationPanelExpandableFlyoutPropsPreview = {
                 id: MisconfigurationFindingsPreviewPanelKey,
                 params: {
                   resourceId: finding.resource.id,
                   ruleId: finding.rule.id,
                   scopeId,
+                  isPreviewMode: true,
                   banner: {
                     title: i18n.translate(
                       'xpack.securitySolution.flyout.right.misconfigurationFinding.PreviewTitle',
@@ -231,7 +234,9 @@ export const MisconfigurationFindingsDetailsTable = memo(
                     textColor: 'warning',
                   },
                 },
-              });
+              };
+
+              openPreviewPanel(previewPanelProps);
             }}
           />
         ),

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/csp_details/findings_flyout/constants.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/csp_details/findings_flyout/constants.ts
@@ -5,10 +5,13 @@
  * 2.0.
  */
 
-import type { FindingsMisconfigurationPanelExpandableFlyoutProps } from '@kbn/cloud-security-posture';
+import type {
+  FindingsMisconfigurationPanelExpandableFlyoutPropsNonPreview,
+  FindingsMisconfigurationPanelExpandableFlyoutPropsPreview,
+} from '@kbn/cloud-security-posture';
 
-export const MisconfigurationFindingsPanelKey: FindingsMisconfigurationPanelExpandableFlyoutProps['key'] =
+export const MisconfigurationFindingsPanelKey: FindingsMisconfigurationPanelExpandableFlyoutPropsNonPreview['id'] =
   'findings-misconfiguration-panel';
 
-export const MisconfigurationFindingsPreviewPanelKey: FindingsMisconfigurationPanelExpandableFlyoutProps['key'] =
+export const MisconfigurationFindingsPreviewPanelKey: FindingsMisconfigurationPanelExpandableFlyoutPropsPreview['id'] =
   'findings-misconfiguration-panel-preview';

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/csp_details/findings_flyout/findings_right/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/csp_details/findings_flyout/findings_right/index.tsx
@@ -6,12 +6,8 @@
  */
 
 import React from 'react';
-import type { FlyoutPanelProps } from '@kbn/expandable-flyout';
 import { EuiFlexGroup, EuiFlexItem, EuiText, EuiSpacer, EuiFlyoutFooter } from '@elastic/eui';
-import type {
-  FindingMisconfigurationFlyoutContentProps,
-  FindingMisconfigurationFlyoutProps,
-} from '@kbn/cloud-security-posture';
+import type { FindingsMisconfigurationPanelExpandableFlyoutProps } from '@kbn/cloud-security-posture';
 import { CspEvaluationBadge } from '@kbn/cloud-security-posture';
 import { i18n } from '@kbn/i18n';
 import { useGetNavigationUrlParams } from '@kbn/cloud-security-posture/src/hooks/use_get_navigation_url_params';
@@ -29,17 +25,11 @@ import { FlyoutTitle } from '../../../shared/components/flyout_title';
 import { FlyoutBody } from '../../../shared/components/flyout_body';
 import { SecuritySolutionLinkAnchor } from '../../../../common/components/links';
 
-export interface FindingsMisconfigurationPanelExpandableFlyoutProps extends FlyoutPanelProps {
-  key: 'findings-misconfiguration-panel';
-  params: FindingMisconfigurationFlyoutProps;
-}
-
 export const FindingsMisconfigurationPanel = ({
   resourceId,
   ruleId,
   isPreviewMode,
-  scopeId,
-}: FindingMisconfigurationFlyoutProps) => {
+}: FindingsMisconfigurationPanelExpandableFlyoutProps['params']) => {
   const { cloudSecurityPosture } = useKibana().services;
   const CspFlyout = cloudSecurityPosture.getCloudSecurityPostureMisconfigurationFlyout();
 
@@ -58,7 +48,7 @@ export const FindingsMisconfigurationPanel = ({
     <>
       <FlyoutNavigation flyoutIsExpandable={false} />
       <CspFlyout.Component ruleId={ruleId} resourceId={resourceId}>
-        {({ finding, createRuleFn }: FindingMisconfigurationFlyoutContentProps) => {
+        {({ finding, createRuleFn }) => {
           return (
             <>
               <FlyoutHeader>

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/index.tsx
@@ -8,7 +8,10 @@
 import React, { memo, useCallback } from 'react';
 import { ExpandableFlyout, type ExpandableFlyoutProps } from '@kbn/expandable-flyout';
 import { useEuiTheme } from '@elastic/eui';
-import type { FindingsMisconfigurationPanelExpandableFlyoutProps } from '@kbn/cloud-security-posture';
+import type {
+  FindingsMisconfigurationPanelExpandableFlyoutPropsNonPreview,
+  FindingsMisconfigurationPanelExpandableFlyoutPropsPreview,
+} from '@kbn/cloud-security-posture';
 import type { AIForSOCDetailsProps } from './ai_for_soc/types';
 import { AIForSOCDetailsProvider } from './ai_for_soc/context';
 import { AIForSOCPanel } from './ai_for_soc';
@@ -201,7 +204,7 @@ const expandableFlyoutDocumentsPanels: ExpandableFlyoutProps['registeredPanels']
     key: MisconfigurationFindingsPanelKey,
     component: (props) => (
       <FindingsMisconfigurationPanel
-        {...(props as FindingsMisconfigurationPanelExpandableFlyoutProps).params}
+        {...(props as FindingsMisconfigurationPanelExpandableFlyoutPropsNonPreview).params}
       />
     ),
   },
@@ -217,8 +220,7 @@ const expandableFlyoutDocumentsPanels: ExpandableFlyoutProps['registeredPanels']
     key: MisconfigurationFindingsPreviewPanelKey,
     component: (props) => (
       <FindingsMisconfigurationPanel
-        {...(props as FindingsMisconfigurationPanelExpandableFlyoutProps).params}
-        isPreviewMode
+        {...(props as FindingsMisconfigurationPanelExpandableFlyoutPropsPreview).params}
       />
     ),
   },


### PR DESCRIPTION
Updates the CSP misconfiguration flyout to differentiate between preview and non-preview modes using distinct prop types.

This change improves type safety and provides better context for the flyout component.



